### PR TITLE
Speed up gpio_extr.h

### DIFF
--- a/keyboards/creatorpad/boost/gpio_extr.h
+++ b/keyboards/creatorpad/boost/gpio_extr.h
@@ -2,52 +2,60 @@
 
 /* Operation of GPIO by port. */
 
-#ifndef readPort
-
 #ifdef PAL_MODE_OUTPUT_OPENDRAIN
 #    ifdef PAL_STM32_PUPDR_PULLUP
 #        define PAL_MODE_OUTPUT_OPENDRAIN_PULLUP (PAL_MODE_OUTPUT_OPENDRAIN | PAL_STM32_PUPDR_PULLUP)
 #    endif
 #endif
 
+#if PAL_IOPORTS_WIDTH == 16
+typedef uint16_t port_data_t;
+#endif
+#if PAL_IOPORTS_WIDTH == 32
 typedef uint32_t port_data_t;
-
-#define readPort(pin) palReadPort(PAL_PORT(pin))
-
-#define setPortBitInput(pin, bit) palSetPadMode(PAL_PORT(pin), (bit), PAL_MODE_INPUT)
-#define setPortBitInputHigh(pin, bit) palSetPadMode(PAL_PORT(pin), (bit), PAL_MODE_INPUT_PULLUP)
-#define setPortBitInputLow(pin, bit) palSetPadMode(PAL_PORT(pin), (bit), PAL_MODE_INPUT_PULLDOWN)
-
-#define setPortBitOutputPushPull(pin, bit) palSetPadMode(PAL_PORT(pin), (bit), PAL_MODE_OUTPUT_PUSHPULL)
-#define setPortBitOutput(pin, bit) setPortBitOutputPushPull(pin, bit)
-
-#ifdef PAL_MODE_OUTPUT_OPENDRAIN
-#    define setPortBitOutputOpenDrain(pin, bit) palSetPadMode(PAL_PORT(pin), (bit), PAL_MODE_OUTPUT_OPENDRAIN)
-#endif
-#ifdef PAL_MODE_OUTPUT_OPENDRAIN_PULLUP
-#    define setPortBitOutputOpenDrainPullup(pin, bit) palSetPadMode(PAL_PORT(pin), (bit), PAL_MODE_OUTPUT_OPENDRAIN_PULLUP)
 #endif
 
-#define writePortBitLow(pin, bit) palClearLine(PAL_LINE(PAL_PORT(pin), (bit)))
-#define writePortBitHigh(pin, bit) palSetLine(PAL_LINE(PAL_PORT(pin), (bit)))
+#ifndef readPort
+#    define readPort(pin) palReadPort(PAL_PORT(pin))
+#endif // readPort
 
-#define setPortBunchInput(port, bunch) palSetGroupMode_wrap(PAL_PORT(port), (bunch), 0, PAL_MODE_INPUT)
-#define setPortBunchInputHigh(port, bunch) palSetGroupMode_wrap(PAL_PORT(port), (bunch), 0, PAL_MODE_INPUT_PULLUP)
+#ifndef setPortBitInput
+#    define setPortBitInput(pin, bit) palSetPadMode(PAL_PORT(pin), (bit), PAL_MODE_INPUT)
+#    define setPortBitInputHigh(pin, bit) palSetPadMode(PAL_PORT(pin), (bit), PAL_MODE_INPUT_PULLUP)
+#    define setPortBitInputLow(pin, bit) palSetPadMode(PAL_PORT(pin), (bit), PAL_MODE_INPUT_PULLDOWN)
 
-#define setPortBunchOutputPusuPull(port, bunch) palSetGroupMode_wrap(PAL_PORT(port), (bunch), 0, PAL_MODE_OUTPUT_PUSHPULL)
-#define setPortBunchOutput(port, bunch) setPortBunchOutputPusuPull(port, bunch)
+#    define setPortBitOutputPushPull(pin, bit) palSetPadMode(PAL_PORT(pin), (bit), PAL_MODE_OUTPUT_PUSHPULL)
+#    define setPortBitOutput(pin, bit) setPortBitOutputPushPull(pin, bit)
 
-#ifdef PAL_MODE_OUTPUT_OPENDRAIN
-#    define setPortBunchOutputOpenDrain(port, bunch) palSetGroupMode_wrap(PAL_PORT(port), (bunch), 0, PAL_MODE_OUTPUT_OPENDRAIN)
-#endif
-#ifdef PAL_MODE_OUTPUT_OPENDRAIN_PULLUP
-#    define setPortBunchOutputOpenDrainPullup(port, bunch) palSetGroupMode_wrap(PAL_PORT(port), (bunch), 0, PAL_MODE_OUTPUT_OPENDRAIN_PULLUP)
-#endif
+#    ifdef PAL_MODE_OUTPUT_OPENDRAIN
+#        define setPortBitOutputOpenDrain(pin, bit) palSetPadMode(PAL_PORT(pin), (bit), PAL_MODE_OUTPUT_OPENDRAIN)
+#    endif
+#    ifdef PAL_MODE_OUTPUT_OPENDRAIN_PULLUP
+#        define setPortBitOutputOpenDrainPullup(pin, bit) palSetPadMode(PAL_PORT(pin), (bit), PAL_MODE_OUTPUT_OPENDRAIN_PULLUP)
+#    endif
 
-#define writePortBunchLow(port, bunch) palWriteGroup(PAL_PORT(port), (bunch), 0, 0)
-#define writePortBunchHigh(port, bunch) palWriteGroup(PAL_PORT(port), (bunch), 0, (bunch))
+#    define writePortBitLow(pin, bit) palClearLine(PAL_LINE(PAL_PORT(pin), (bit)))
+#    define writePortBitHigh(pin, bit) palSetLine(PAL_LINE(PAL_PORT(pin), (bit)))
+#endif // setPortBitInput
 
-#define palSetGroupMode_wrap(port, bunch, offset, mode) palSetGroupMode((port), (bunch), (offset), (mode))
+#ifndef setPortBunchInput
+#    define setPortBunchInput(port, bunch) palSetGroupMode_wrap(PAL_PORT(port), (bunch), 0, PAL_MODE_INPUT)
+#    define setPortBunchInputHigh(port, bunch) palSetGroupMode_wrap(PAL_PORT(port), (bunch), 0, PAL_MODE_INPUT_PULLUP)
+
+#    define setPortBunchOutputPusuPull(port, bunch) palSetGroupMode_wrap(PAL_PORT(port), (bunch), 0, PAL_MODE_OUTPUT_PUSHPULL)
+#    define setPortBunchOutput(port, bunch) setPortBunchOutputPusuPull(port, bunch)
+
+#    ifdef PAL_MODE_OUTPUT_OPENDRAIN
+#        define setPortBunchOutputOpenDrain(port, bunch) palSetGroupMode_wrap(PAL_PORT(port), (bunch), 0, PAL_MODE_OUTPUT_OPENDRAIN)
+#    endif
+#    ifdef PAL_MODE_OUTPUT_OPENDRAIN_PULLUP
+#        define setPortBunchOutputOpenDrainPullup(port, bunch) palSetGroupMode_wrap(PAL_PORT(port), (bunch), 0, PAL_MODE_OUTPUT_OPENDRAIN_PULLUP)
+#    endif
+
+#    define writePortBunchLow(port, bunch) palWriteGroup(PAL_PORT(port), (bunch), 0, 0)
+#    define writePortBunchHigh(port, bunch) palWriteGroup(PAL_PORT(port), (bunch), 0, (bunch))
+
+#    define palSetGroupMode_wrap(port, bunch, offset, mode) palSetGroupMode((port), (bunch), (offset), (mode))
 
 // ChibiOS's GPIO implementation for RP2040 doesn't seem to implement palSetGroupMode(),
 // so as a workaround, use the implementation below.
@@ -56,13 +64,22 @@ typedef uint32_t port_data_t;
 #        undef palSetGroupMode_wrap
 
 #        define palSetGroupMode_wrap(port, mask, offset, mode)           \
-             palSetGroupMode_impl((port), (mask), (offset), (mode))
+                palSetGroupMode_impl((port), (mask), (offset), (mode))
 #        define palSetGroupMode_impl(port, mask, offset, mode)           \
-             _palSetGroupMode_impl((port), ((mask) << (offset)), (mode))
+                _palSetGroupMode_impl((port), ((mask) << (offset)), (mode))
 
 static inline void _palSetGroupMode_impl(ioportid_t port, ioportmask_t mask, iomode_t mode) {
     iopadid_t pad = 0;
+
+    while (((mask) & 0xff) == 0) {
+        pad += 8;
+        mask = mask >> 8;
+    }
     while (mask != 0) {
+        while (((mask) & 0xf) == 0) {
+            pad += 4;
+            mask = mask >> 4;
+        }
         if ((mask & 1) != 0) {
             palSetPadMode(port, pad, mode);
         }
@@ -71,5 +88,4 @@ static inline void _palSetGroupMode_impl(ioportid_t port, ioportmask_t mask, iom
     }
 }
 #    endif // ifndef pal_lld_setgroupmode
-
-#endif // ifndef readPort
+#endif // setPortBunchInput

--- a/keyboards/creatorpad/boost/matrix_read_cols_on_row.c
+++ b/keyboards/creatorpad/boost/matrix_read_cols_on_row.c
@@ -115,10 +115,8 @@ enum DEVICE_NAME {
 #    include "matrix.h"
 #    include "atomic_util.h"
 #    include "gpio.h"
-#    ifndef readPort
-#        include "gpio_extr.h"
-#    endif
-#    ifndef readPort
+#    include "gpio_extr.h"
+#    if ! (defined(readPort) && defined(setPortBunchInput))
 #        error matrix_read_cols_on_row.c requires readPort() and related macros.
 #    endif
 #    ifdef setPortBunchOutputOpenDrainPullup
@@ -234,6 +232,14 @@ const static port_pin_list_element_t minfo[] = {
     }
 #endif
 };
+
+#ifdef MATRIX_SELECT_IO_DELAY_US
+// To use microsecond delays instead of CPU clock delays,
+// replace the matrix_output_select_delay() function in matrix_common.c with the following function
+void matrix_output_select_delay(void) {
+    wait_us(MATRIX_SELECT_IO_DELAY_US);
+}
+#endif
 
 // clang-format on
 ALWAYS_INLINE
@@ -610,12 +616,12 @@ void matrix_read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row)
     DEBUG_PIN_ON();
     select_output(current_row);
     matrix_output_select_delay();
-    MATRIX_DEBUG_SCAN_END();
+    //MATRIX_DEBUG_SCAN_END();
     read_all_pins(port_buffer);
     unselect_output(current_row);
     DEBUG_PIN_OFF();
     key_pressed = mask_and_adjust_pins(port_buffer);
-    MATRIX_DEBUG_SCAN_START();
+    //MATRIX_DEBUG_SCAN_START();
     if (key_pressed) {
         current_row_value = build_line(port_buffer);
     }


### PR DESCRIPTION
## Description

gpio_extr.h の中の `void _palSetGroupMode_impl()` が、CreatorPad のピンアサインでは少し遅かったので最適化しました。
Row 系のピンが高いビットに割り当たっていたので、ずぼらな実装でスピードが出ていませんでした。

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation


